### PR TITLE
support linux prefork for better performance

### DIFF
--- a/protocol/fiber4r/fiber4r_test.go
+++ b/protocol/fiber4r/fiber4r_test.go
@@ -16,7 +16,10 @@ func TestFiberServer_Start(t *testing.T) {
 		Address:       "127.0.0.1:3000",
 		MetricsEnable: true,
 	})
-	app := fiber.New()
+	app := fiber.New(fiber.Config{
+		Prefork: true,
+		Network: "tcp4",
+	})
 	app.Get("/hello", Handler)
 	t.Run("register right ptr,should success", func(t *testing.T) {
 		_, err := s.Register(app)
@@ -26,7 +29,8 @@ func TestFiberServer_Start(t *testing.T) {
 		_, err := s.Register("")
 		assert.Error(t, err)
 	})
-	go s.Start()
+	err := s.Start()
+	assert.NoError(t, err)
 	time.Sleep(2 * time.Second)
 
 	t.Run("call http server, should success", func(t *testing.T) {
@@ -41,6 +45,7 @@ func TestFiberServer_Start(t *testing.T) {
 		c := http.DefaultClient
 		r, err := c.Do(req)
 		assert.NoError(t, err)
+
 		assert.Equal(t, http.StatusOK, r.StatusCode)
 	})
 


### PR DESCRIPTION
parent进程再并发拉子进程时，使用net listener做监听，会引发端口冲突。因此加了重试机制。这是一种临时规避，但是行之有效